### PR TITLE
Remove unnecessary attribute

### DIFF
--- a/src/main/scala/com/gu/email/xml/subscriptions.scala
+++ b/src/main/scala/com/gu/email/xml/subscriptions.scala
@@ -59,8 +59,7 @@ class SubscriberUpdateMessageEncoder extends MessageEncoder[SubscriberUpdateRequ
       <Client>
         <ID>{businessUnitId}</ID>
       </Client>
-      ).getOrElse(Nil)}<ObjectID xsi:nil="true">
-    </ObjectID>
+      ).getOrElse(Nil)}
       <EmailAddress>{subscriber.email}</EmailAddress>
       <SubscriberKey>{subscriber.email}</SubscriberKey>
       {subscriber.emailTypePreference.map(preference =>
@@ -78,8 +77,7 @@ class SubscriberUpdateMessageEncoder extends MessageEncoder[SubscriberUpdateRequ
                   }
             }++
             <Status>{emailList.status}</Status>
-          } }<ObjectID xsi:nil="true">
-          </ObjectID>
+          } }
           </Lists>
         }
       }
@@ -125,7 +123,6 @@ class SubscriberRetrieveMessageEncoder(accountDetails: AccountDetails) extends M
       <soapenv:Body>
         <RetrieveRequestMsg xmlns="http://exacttarget.com/wsdl/partnerAPI">
           <RetrieveRequest>
-            <ObjectType>Subscriber</ObjectType>
             <ObjectType>Subscriber</ObjectType>
             <Properties>ID</Properties>
             <Properties>CreatedDate</Properties>

--- a/src/test/scala/com/gu/email/xml/SubscriberRetrieveMessageEncoderTest.scala
+++ b/src/test/scala/com/gu/email/xml/SubscriberRetrieveMessageEncoderTest.scala
@@ -27,7 +27,6 @@ class SubscriberRetrieveMessageEncoderTest extends FlatSpec with MockitoSugar wi
           <RetrieveRequestMsg xmlns="http://exacttarget.com/wsdl/partnerAPI">
             <RetrieveRequest>
               <ObjectType>Subscriber</ObjectType>
-              <ObjectType>Subscriber</ObjectType>
               <Properties>ID</Properties>
               <Properties>CreatedDate</Properties>
               <Properties>Client.ID</Properties>
@@ -70,7 +69,6 @@ class SubscriberRetrieveMessageEncoderTest extends FlatSpec with MockitoSugar wi
             <PartnerKey xsi:nil="true"/>
             <CreatedDate>2012-12-07T06:57:00</CreatedDate>
             <ID>5797215</ID>
-            <ObjectID xsi:nil="true"/>
             <EmailAddress>foo@blah.com</EmailAddress>
             <Attributes>
               <Name>First Name</Name>

--- a/src/test/scala/com/gu/email/xml/SubscriberUpdateMessageEncoderTest.scala
+++ b/src/test/scala/com/gu/email/xml/SubscriberUpdateMessageEncoderTest.scala
@@ -52,16 +52,12 @@ class SubscriberUpdateMessageEncoderTest extends FlatSpec with MockitoSugar with
               <Client>
                 <ID>aBusinessUnitId</ID>
               </Client>
-              <ObjectID xsi:nil="true">
-              </ObjectID>
               <EmailAddress>anEmailAddress</EmailAddress>
               <SubscriberKey>anEmailAddress</SubscriberKey>
               <EmailTypePreference>anEmailPreference</EmailTypePreference>
               <Lists>
                 <ID>12345</ID>
                 <Status>aStatus</Status>
-                <ObjectID xsi:nil="true">
-                </ObjectID>
               </Lists>
               <Attributes>
                 <Name>First Name</Name>
@@ -121,16 +117,12 @@ class SubscriberUpdateMessageEncoderTest extends FlatSpec with MockitoSugar with
               <Client>
                 <ID>aBusinessUnitId</ID>
               </Client>
-              <ObjectID xsi:nil="true">
-              </ObjectID>
               <EmailAddress>anEmailAddress</EmailAddress>
               <SubscriberKey>anEmailAddress</SubscriberKey>
               <EmailTypePreference>anEmailPreference</EmailTypePreference>
               <Lists>
                 <PartnerKey>nonNumericSoUseCustomerKey</PartnerKey>
                 <Status>aStatus</Status>
-                <ObjectID xsi:nil="true">
-                </ObjectID>
               </Lists>
               <Attributes>
                 <Name>First Name</Name>
@@ -178,13 +170,11 @@ class SubscriberUpdateMessageEncoderTest extends FlatSpec with MockitoSugar with
                 </Client>
                 <PartnerKey xsi:nil="true" />
                 <ID>5797215</ID>
-                <ObjectID xsi:nil="true" />
                 <EmailAddress>13219403-francis@rhys-jones.com</EmailAddress>
                 <SubscriberKey>13219403-francis@rhys-jones.com</SubscriberKey>
                 <Lists>
                   <PartnerKey xsi:nil="true" />
                   <ID>217</ID>
-                  <ObjectID xsi:nil="true" />
                   <Status>Unsubscribed</Status>
                 </Lists>
               </Object>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1"
+version in ThisBuild := "4.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1-SNAPSHOT"
+version in ThisBuild := "4.1"


### PR DESCRIPTION
`ObjectId` is not necessary in the SOAP envelope:

`System-controlled, read-only text string identifier for object.`

https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/subscriber.htm
