### PR TITLE
Fix error - multiple listId format

### DIFF
--- a/src/main/scala/com/gu/email/xml/subscriptions.scala
+++ b/src/main/scala/com/gu/email/xml/subscriptions.scala
@@ -66,18 +66,10 @@ class SubscriberUpdateMessageEncoder extends MessageEncoder[SubscriberUpdateRequ
       <EmailTypePreference>{preference}</EmailTypePreference>
     ).getOrElse(Nil)}
       {
-        if(!subscriber.subscriptions.isEmpty) {
+        subscriber.subscriptions.map { emailList =>
           <Lists>
-            {subscriber.subscriptions.map {
-            emailList => {
-                  if ( emailList.listId.isAllDigits ) {
-                    <ID>{emailList.listId}</ID>
-                  } else {
-                      <PartnerKey>{emailList.listId}</PartnerKey>
-                  }
-            }++
+            <ID>{emailList.listId}</ID>
             <Status>{emailList.status}</Status>
-          } }
           </Lists>
         }
       }

--- a/src/test/scala/com/gu/email/xml/SubscriberUpdateMessageEncoderTest.scala
+++ b/src/test/scala/com/gu/email/xml/SubscriberUpdateMessageEncoderTest.scala
@@ -82,7 +82,7 @@ class SubscriberUpdateMessageEncoderTest extends FlatSpec with MockitoSugar with
       AccountDetails("ausername", "apassword"),
       List(
         Subscriber("anEmailAddress", Some("aFirstName"), Some("aSecondName"), None, None, Some("aStatus"),
-          Some("anEmailPreference"), List(EmailList("nonNumericSoUseCustomerKey", "aStatus")))
+          Some("anEmailPreference"), List(EmailList("12345", "aStatus")))
       )
     )
 
@@ -121,7 +121,7 @@ class SubscriberUpdateMessageEncoderTest extends FlatSpec with MockitoSugar with
               <SubscriberKey>anEmailAddress</SubscriberKey>
               <EmailTypePreference>anEmailPreference</EmailTypePreference>
               <Lists>
-                <PartnerKey>nonNumericSoUseCustomerKey</PartnerKey>
+                <ID>12345</ID>
                 <Status>aStatus</Status>
               </Lists>
               <Attributes>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.3"
+version in ThisBuild := "4.4-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.3-SNAPSHOT"
+version in ThisBuild := "4.3"


### PR DESCRIPTION
Fixing this allows a single call to subscribe multiple lists.

The format should be 

```
<Lists>
  <ID>4146</ID>
  <Status>Active</Status>
</Lists>
<Lists>
  <ID>4148</ID>
  <Status>Active</Status>
 </Lists>
<Lists>
  <ID>4150</ID>
  <Status>Active</Status>
</Lists>
```
instead of

```
<Lists>
  <ID>4146</ID>
  <Status>Active</Status>
  <ID>4148</ID>
  <Status>Active</Status>
  <ID>4150</ID>
  <Status>Active</Status>
</Lists>
```


</Lists>